### PR TITLE
 [FIX} Remove Gitlab deps from Hyper_bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.4 - Stable Release Alsaqr 2 branch: alsaqr_2_130525 - 13/05/2025
+
+### Hardware
+
+### Interface/Feature frozen macros:
+- Culsans
+- Hyperbus
+- OpenTitan
+- Cluster
+- TOP
+
+### Work In progress (RTL FROZEN)
+- Further testing
+
+### Changed (bug fixes):
+- REPO: removed gitlab dependencies  (not needed and causing errors due to permissions)
+
 ## 2.0.3 - Stable Release Alsaqr 2 branch: alsaqr_2_050525 - 05/05/2025
 
 ### Hardware

--- a/hardware/Bender.lock
+++ b/hardware/Bender.lock
@@ -17,7 +17,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/alsaqr_periph_fpga_padframe
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/alsaqr_periph_fpga_padframe
     dependencies:
       - common_cells
       - register_interface
@@ -25,7 +25,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/alsaqr_periph_padframe
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/alsaqr_periph_padframe
     dependencies:
       - common_cells
       - register_interface
@@ -60,7 +60,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/apb_host_control_regs
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/apb_host_control_regs
     dependencies:
       - common_cells
       - register_interface
@@ -75,7 +75,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/apb_uart
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/apb_uart
     dependencies: []
   apmu:
     revision: f8d57d3ede962e50e90aa037d55acc37b98f09c7
@@ -164,7 +164,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/axi_tlb
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/axi_tlb
     dependencies:
       - axi
       - common_cells
@@ -180,7 +180,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/clint
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/clint
     dependencies:
       - cva6
   cluster_interconnect:
@@ -322,7 +322,7 @@ packages:
       - register_interface
       - tech_cells_generic
   hyperbus_udma:
-    revision: 600063d2b2ea3d8447820a94ab046bf532c0da71
+    revision: b1e719a0f90ec47d1d275465386764dfee81536d
     version: ~
     source:
       Git: "git@github.com:AlSaqr-platform/hyper_bus.git"
@@ -504,7 +504,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/rv_plic
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/rv_plic
     dependencies: []
   scm:
     revision: 998466d2a3c2d7d572e43d2666d93c4f767d8d60
@@ -522,7 +522,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/snooper
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/snooper
     dependencies: []
   spu:
     revision: e213cb2e10d713531b718fdaddacdbd605f23ff6
@@ -623,7 +623,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-bug-fixes/hardware/deps/util
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tags/he-soc-delivery-13-05-25/hardware/deps/util
     dependencies:
       - axi
       - common_cells

--- a/hardware/Bender.yml
+++ b/hardware/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", rev: "c27bce39ebb2e6bae52f60960814a2afca7bd4cb" } # version: 1.37.0 }
   apb_node: { git: "https://github.com/pulp-platform/apb_node.git", rev: "d436ab3dad8260eadc1288bdc543c79b4d7462c7" }
   apb_gpio: { git: "https://github.com/pulp-platform/apb_gpio.git", rev: "c1feb0b348d15fecce907ae847f78c2f91d43bde" }
-  hyperbus_udma: { git: "git@github.com:AlSaqr-platform/hyper_bus.git", rev: "600063d2b2ea3d8447820a94ab046bf532c0da71" } # branch: master
+  hyperbus_udma: { git: "git@github.com:AlSaqr-platform/hyper_bus.git", rev: "b1e719a0f90ec47d1d275465386764dfee81536d" } # branch: alsaqr-2
   apb_fll_if: { git: "git@github.com:AlSaqr-platform/apb_fll_if.git", rev: "41e03443848a533df99dbe416b0d8c8ff67bc21e" } #  version: 1.0.1
   register_interface: { git: "git@github.com:pulp-platform/register_interface.git",   rev: "5daa85d164cf6b54ad061ea1e4c6f3624556e467" } # version:  0.4.5
   apb_adv_timer: { git: "https://github.com/pulp-platform/apb_adv_timer.git", rev: "c8faec1e1755386d0e0f31a55ebd80612a3dcea9" } # version: 1.0.4


### PR DESCRIPTION
Was including stuff (not needed) from zurich's gitlab. removed.