### PR TITLE
[BUG FIX] Fixing a reset connection for cluster and remapping L1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.9 - Stable Release Alsaqr 2 branch: alsaqr_2_010925 - 01/09/2025
+
+### Hardware
+
+### Interface/Feature frozen macros:
+- Culsans
+- Hyperbus
+- OpenTitan
+- Cluster
+- TOP
+
+### Work In progress (RTL FROZEN, TEST FROZEN)
+- At the time being, all the known bugs have been fixed. No more updates expected
+
+### Changed (bug fixes):
+- OPENTITAN: fixed reset connection of cluster's slave port CDC.
+- CLUSTER: Remapped L1 to avoid conflicts in OpenTitan mem map.
+
 ## 2.0.8 - Stable Release Alsaqr 2 branch: alsaqr_2_220725 - 22/07/2025
 
 ### Hardware

--- a/hardware/Bender.lock
+++ b/hardware/Bender.lock
@@ -17,7 +17,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/alsaqr_periph_fpga_padframe
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/alsaqr_periph_fpga_padframe
     dependencies:
       - common_cells
       - register_interface
@@ -25,7 +25,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/alsaqr_periph_padframe
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/alsaqr_periph_padframe
     dependencies:
       - common_cells
       - register_interface
@@ -60,7 +60,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/apb_host_control_regs
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/apb_host_control_regs
     dependencies:
       - common_cells
       - register_interface
@@ -75,7 +75,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/apb_uart
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/apb_uart
     dependencies: []
   apmu:
     revision: f8d57d3ede962e50e90aa037d55acc37b98f09c7
@@ -164,7 +164,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/axi_tlb
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/axi_tlb
     dependencies:
       - axi
       - common_cells
@@ -180,7 +180,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/clint
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/clint
     dependencies:
       - cva6
   cluster_interconnect:
@@ -394,7 +394,7 @@ packages:
       - common_cells
       - common_verification
   opentitan:
-    revision: 727b020381b5e6bd14fb23acb3f250c522f64f14
+    revision: 4b5358fbfcb3eba36f6d450350aa8c9e775f82ea
     version: ~
     source:
       Git: "https://github.com/AlSaqr-platform/opentitan.git"
@@ -504,7 +504,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/rv_plic
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/rv_plic
     dependencies: []
   scm:
     revision: 998466d2a3c2d7d572e43d2666d93c4f767d8d60
@@ -522,7 +522,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/snooper
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/snooper
     dependencies: []
   spu:
     revision: dd5f79d5072be4571511a57d200f5aa18fd93f8d
@@ -623,7 +623,7 @@ packages:
     revision: ~
     version: ~
     source:
-      Path: /scratch2/mciani/alsaqr-2/deliveries/he-soc-fix-apmu-2/hardware/deps/util
+      Path: /scratch2/mciani/alsaqr-2/deliveries/tapeout/he-soc/hardware/deps/util
     dependencies:
       - axi
       - common_cells

--- a/hardware/Bender.lock
+++ b/hardware/Bender.lock
@@ -394,7 +394,7 @@ packages:
       - common_cells
       - common_verification
   opentitan:
-    revision: cc9d4be27eeeb4e45a0309d284886767e786f3ed
+    revision: 727b020381b5e6bd14fb23acb3f250c522f64f14
     version: ~
     source:
       Git: "https://github.com/AlSaqr-platform/opentitan.git"
@@ -412,7 +412,7 @@ packages:
     dependencies:
       - axi_slice
   pulp_cluster:
-    revision: 4aa4951c832a782a4ef9dbcb4a32592b0a499d44
+    revision: 4f7ccca3ee65028b3b251a8f7d9a644e8f8ffac4
     version: ~
     source:
       Git: "git@github.com:AlSaqr-platform/pulp_cluster.git"

--- a/hardware/Bender.yml
+++ b/hardware/Bender.yml
@@ -39,7 +39,7 @@ dependencies:
   apb_adv_timer: { git: "https://github.com/pulp-platform/apb_adv_timer.git", rev: "c8faec1e1755386d0e0f31a55ebd80612a3dcea9" } # version: 1.0.4
   can_bus: { git: "git@github.com:alsaqr-platform/can_bus.git", rev: "0ec0bf8b7dab6d5e4b3f7ec58338a8efee066379" }
   common_pads: { git: "git@github.com:AlSaqr-platform/common_pads.git", rev: "4ce2907ab2313e67836e251f6deea67d885aef5f" } # version: 0.0.4
-  opentitan: { git: "https://github.com/AlSaqr-platform/opentitan.git", rev: "727b020381b5e6bd14fb23acb3f250c522f64f14" } # branch: alsaqr-2
+  opentitan: { git: "https://github.com/AlSaqr-platform/opentitan.git", rev: "4b5358fbfcb3eba36f6d450350aa8c9e775f82ea" } # branch: alsaqr-2
   axi_scmi_mailbox: { git: "git@github.com:AlSaqr-platform/axi_scmi_mailbox.git", rev: "96650c4c39dcfc683e48015abb1453d182c1d837" }
   ethernet: { git: "git@github.com:AlSaqr-platform/ethernet.git", rev: "f2c8a5040596476ee1769292a7c48df9b1c05949" }
   sdio_vip: { git: "git@github.com:AlSaqr-platform/sdio_vip.git", rev: "9793d5f0ac7c72bf06a5ebfedf242dae42eb57f7" }

--- a/hardware/Bender.yml
+++ b/hardware/Bender.yml
@@ -39,7 +39,7 @@ dependencies:
   apb_adv_timer: { git: "https://github.com/pulp-platform/apb_adv_timer.git", rev: "c8faec1e1755386d0e0f31a55ebd80612a3dcea9" } # version: 1.0.4
   can_bus: { git: "git@github.com:alsaqr-platform/can_bus.git", rev: "0ec0bf8b7dab6d5e4b3f7ec58338a8efee066379" }
   common_pads: { git: "git@github.com:AlSaqr-platform/common_pads.git", rev: "4ce2907ab2313e67836e251f6deea67d885aef5f" } # version: 0.0.4
-  opentitan: { git: "https://github.com/AlSaqr-platform/opentitan.git", rev: "cc9d4be27eeeb4e45a0309d284886767e786f3ed" } # branch: alsaqr-2
+  opentitan: { git: "https://github.com/AlSaqr-platform/opentitan.git", rev: "727b020381b5e6bd14fb23acb3f250c522f64f14" } # branch: alsaqr-2
   axi_scmi_mailbox: { git: "git@github.com:AlSaqr-platform/axi_scmi_mailbox.git", rev: "96650c4c39dcfc683e48015abb1453d182c1d837" }
   ethernet: { git: "git@github.com:AlSaqr-platform/ethernet.git", rev: "f2c8a5040596476ee1769292a7c48df9b1c05949" }
   sdio_vip: { git: "git@github.com:AlSaqr-platform/sdio_vip.git", rev: "9793d5f0ac7c72bf06a5ebfedf242dae42eb57f7" }

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -41,6 +41,7 @@ BOOTMODE       ?= 0
 OT_FLASH       ?= ./opentitan/sw/tests/alsaqr/flash_alsaqr_boot/bazel-out/flash_alsaqr_boot_signed8.vmem
 #cl-bin         ?= ../software/pulp/mm.riscv
 cl-bin         ?= none
+OT_CLUSTER     = $(cl-bin)
 # root pathelf-bin
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 root-dir := $(dir $(mkfile_path))
@@ -477,12 +478,12 @@ generate-trace-vsim:
 	make generate-trace
 
 run:
-	$(QUESTA) vsim +permissive $(questa-flags) $(questa-cmd) -suppress 3053 -suppress 8885 -suppress 3999 -suppress 8386 -suppress 8360 -lib $(library) +OT_FLASH=$(OT_FLASH) +CORE_ID=$(CORE_ID) +BOOTMODE=$(BOOTMODE) +OT_SRAM=$(ibex-elf-bin)  +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) +CVA6_STRING=$(elf-bin) +CL_STRING=$(cl-bin) +notimingchecks +nospecify  -t 1ps \
+	$(QUESTA) vsim +permissive $(questa-flags) $(questa-cmd) -suppress 3053 -suppress 8885 -suppress 3999 -suppress 8386 -suppress 8360 -lib $(library) +OT_CLUSTER=$(OT_CLUSTER) +OT_FLASH=$(OT_FLASH) +CORE_ID=$(CORE_ID) +BOOTMODE=$(BOOTMODE) +OT_SRAM=$(ibex-elf-bin)  +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) +CVA6_STRING=$(elf-bin) +CL_STRING=$(cl-bin) +notimingchecks +nospecify  -t 1ps \
 	$(uvm-flags) $(QUESTASIM_FLAGS) -sv_lib $(dpi-library)/ariane_dpi  \
 	${top_level}_optimized +permissive-off ++$(elf-bin) ++$(target-options) ++$(cl-bin) | tee sim.log
 
 run_dbg:
-	$(QUESTA) vsim +permissive $(questa-flags) $(questa-cmd) -debugDB -suppress 3053 -suppress 8885 -suppress 3999 -suppress 8386 -suppress 8360 -lib $(library) +OT_FLASH=$(OT_FLASH) +CORE_ID=$(CORE_ID) +BOOTMODE=$(BOOTMODE) +OT_SRAM=$(ibex-elf-bin)  +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) +CVA6_STRING=$(elf-bin) +CL_STRING=$(cl-bin) +notimingchecks +nospecify  -t 1ps \
+	$(QUESTA) vsim +permissive $(questa-flags) $(questa-cmd) -debugDB -suppress 3053 -suppress 8885 -suppress 3999 -suppress 8386 -suppress 8360 -lib $(library) +OT_CLUSTER=$(OT_CLUSTER) +OT_FLASH=$(OT_FLASH) +CORE_ID=$(CORE_ID) +BOOTMODE=$(BOOTMODE) +OT_SRAM=$(ibex-elf-bin)  +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) +CVA6_STRING=$(elf-bin) +CL_STRING=$(cl-bin) +notimingchecks +nospecify  -t 1ps \
 	$(uvm-flags) $(QUESTASIM_FLAGS) -sv_lib $(dpi-library)/ariane_dpi  \
 	${top_level}_optimized +permissive-off ++$(elf-bin) ++$(target-options) ++$(cl-bin) | tee sim.log
 

--- a/hardware/regression.py
+++ b/hardware/regression.py
@@ -59,7 +59,7 @@ try:
                     "set -x; "  # Enable command tracing
                     f"make scripts_vip_macro {scripts_args_str} && "
                     f"make -C {cva6} clean all && "
-                    f"make clean macro_sim BOOTMODE={bm} ibex-elf-bin={ot} nogui=1 && "
+                    f"make clean macro_sim BOOTMODE={bm} ibex-elf-bin={ot} cl-bin={cl} nogui=1 && "
                     f"mv transcript {test_dir}/transcript.log && "
                     f"mv trace_*.log {test_dir}/"
                 )

--- a/hardware/regressions/regression.csv
+++ b/hardware/regressions/regression.csv
@@ -25,7 +25,7 @@
 0,../software/monitor_counter,none,none,,,,,0
 0,../software/htm,none,none,,,,,0
 0,../software/mbox_test,opentitan/sw/tests/alsaqr/mbox_test/mbox_test.elf,none,,,,,0
-0,../software/hello_culsans,opentitan/sw/tests/opentitan/idma_test/idma_test.elf,none,,1,,,0
+0,../software/hello_culsans,opentitan/sw/tests/opentitan/idma_test_advanced/bazel-out/idma_test.elf,none,,1,,,0
 0,../software/hello_culsans,opentitan/sw/tests/cluster/mbox_test/mbox_test.elf,none,,1,,,0
 0,../software/hello_culsans,opentitan/sw/tests/cluster/par_matmul_fp32/par_matmul_fp32.elf,none,,1,,,0
 0,../software/hello_culsans,opentitan/sw/tests/opentitan/monitor_counter/bazel-out/monitor_counter.elf,none,,1,,,0

--- a/hardware/tb/ariane_tb.sv
+++ b/hardware/tb/ariane_tb.sv
@@ -401,6 +401,7 @@ module ariane_tb;
     string        binary ;
     string        cluster_binary;
     string        ot_sram;
+    string        ot_cluster;
     string        ot_flash;
 
     logic         cid;
@@ -3802,6 +3803,11 @@ uart_bus #(.BAUD_RATE(115200), .PARITY_EN(0)) i_uart0_bus (.rx(pad_periphs_a_00_
         ot_sram="none";
         $display("Loading to SRAM: %s", ot_sram);
      end
+     //if(!$value$plusargs("OT_CLUSTER=%s", ot_cluster)) begin
+     //   ot_cluster="none";
+     //   $display("OT_CLUSTER: %s", ot_cluster);
+     //end
+     ot_cluster="none";
      case(boot_mode)
          0:begin
            bootmode = 1'b0;
@@ -3812,6 +3818,10 @@ uart_bus #(.BAUD_RATE(115200), .PARITY_EN(0)) i_uart0_bus (.rx(pad_periphs_a_00_
                 debug_secd_module_init();
                 load_secd_binary(ot_sram);
                 jtag_secd_data_preload();
+                if(ot_cluster != "none") begin
+                   load_secd_binary(ot_cluster);
+                   jtag_secd_data_preload();
+                end
                 jtag_secd_wakeup(32'h e0000080); //preload the flashif
                 jtag_secd_wait_eoc();
            end


### PR DESCRIPTION
L1 of cluster was unaccessible to OpenTitan due to address conflicts. Remapped L1 to fix the issue.
The reset of the CDC of the cluster slave port was connected to a non-existing signal (floating).

These are the last known bugs we are fixing.